### PR TITLE
データ取得のページが表示されていなかったバグを修正 カード名の分割ロジックを変更

### DIFF
--- a/app/src/main/java/net/poringsoft/wixossbrowser/NavigationDrawerFragment.java
+++ b/app/src/main/java/net/poringsoft/wixossbrowser/NavigationDrawerFragment.java
@@ -57,6 +57,8 @@ public class NavigationDrawerFragment extends Fragment {
             put("WX03", "WX03 スプレッドセレクター");
             put("WX04", "WX04 インフェクテッドセレクター");
             put("WX05", "WX05 ビギニングセレクター");
+            put("WX06", "WX06 フォーチュンセレクター");
+            put("WX07", "WX07 ネクストセレクター");
             put("WD01", "WD01 ホワイトホープ");
             put("WD02", "WD02 レッドアンビション");
             put("WD03", "WD03 ブルーアプリ");
@@ -64,11 +66,17 @@ public class NavigationDrawerFragment extends Fragment {
             put("WD05", "WD05 ブラックデザイア");
             put("WD06", "WD06 ブルーリクエスト");
             put("WD07", "WD07 ブラッククレイヴ");
+            put("WD08", "WD08 ブラックウィル");
+            put("WD09", "WD09 ホワイトプレイ");
+            put("WD10", "WD10 レッドホープ");
             put("PR", "PR プロモカード");
             put("SP01", "SP01 アニメBOX1");
             put("SP02", "SP02 アニメBOX2");
             put("SP03", "SP03 アニメBOX3");
             put("SP05", "SP04 カードガム");
+            put("SP06", "SP06 アニメ2期BOX1");
+            put("SP07", "SP07 アニメ2期BOX2");
+            put("SP08", "SP08 アニメ2期BOX3");
         }
     };
 
@@ -117,6 +125,7 @@ public class NavigationDrawerFragment extends Fragment {
             put("アン", "アン");
             put("リメンバ", "リメンバ");
             put("リメンバ/ピルルク", "リメンバ/ピルルク");
+            put("サシェ", "サシェ");
             put("精武：アーム", "精武：アーム");
             put("精武：ウェポン", "精武：ウェポン");
             put("精武：アーム/ウェポン", "精武：アーム/ウェポン");

--- a/app/src/main/java/net/poringsoft/wixossbrowser/data/CardInfo.java
+++ b/app/src/main/java/net/poringsoft/wixossbrowser/data/CardInfo.java
@@ -80,10 +80,10 @@ public class CardInfo {
      * カード名をセットする
      */
     public void setName(String name) {
-        int delPos = name.indexOf("＜");
+        int delPos = name.indexOf("＞");
         if (delPos != -1)
         {
-            name = name.substring(0, delPos);
+            name = name.substring(delPos+1, name.length());
         }
 
         this.m_name = name;

--- a/app/src/main/java/net/poringsoft/wixossbrowser/data/ProductListHtmlParser.java
+++ b/app/src/main/java/net/poringsoft/wixossbrowser/data/ProductListHtmlParser.java
@@ -40,7 +40,7 @@ public class ProductListHtmlParser {
             return null;
         }
 
-        Elements boxElements = doc.select("div.column2_box_main_contents h5 a");
+        Elements boxElements = doc.select("li h5 a");
         for (Element e : boxElements)
         {
             ProductInfo info = new ProductInfo();


### PR DESCRIPTION
はじめまして、
ウィクロイドをいつも使わせていただいております。
データの取得らへんが上手くいっていなかったようなので、修正してみました。
また定義の部分も各弾の名前の定義を追加しました。
よろしければ取り込んでいただけますでしょうか？
